### PR TITLE
Added image upload endpoint

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -8,6 +8,7 @@ from database import engine, get_db, init_db
 from services.rule_loader import sync_rules_to_db
 from routers.ocr import router as ocr_router
 from routers.compliance import router as compliance_router
+from routers.uploads import router as uploads_router
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
@@ -36,6 +37,7 @@ app.add_middleware(
 # Register Routers
 app.include_router(ocr_router)
 app.include_router(compliance_router)
+app.include_router(uploads_router)
 
 
 @app.get("/", tags=["Health"])

--- a/server/routers/uploads.py
+++ b/server/routers/uploads.py
@@ -1,0 +1,64 @@
+from pathlib import Path
+from uuid import uuid4
+
+from fastapi import APIRouter, Depends, File, HTTPException, UploadFile, status
+from sqlalchemy.orm import Session
+
+from database import get_db
+from models import Inspection
+
+router = APIRouter(prefix="/api/v1/uploads", tags=["Image Uploads"])
+
+UPLOAD_DIR = Path(__file__).resolve().parent.parent / "uploads"
+ALLOWED_EXTENSIONS = {".jpg", ".jpeg", ".png", ".webp", ".gif", ".bmp"}
+
+
+@router.post("/image", status_code=status.HTTP_201_CREATED)
+async def upload_image(
+    file: UploadFile = File(..., description="Label photo file"),
+    db: Session = Depends(get_db),
+):
+    if not file.content_type or not file.content_type.startswith("image/"):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Invalid file type. An image file is required.",
+        )
+
+    image_bytes = await file.read()
+    if not image_bytes:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Uploaded image file is empty.",
+        )
+
+    extension = Path(file.filename or "").suffix.lower()
+    if extension not in ALLOWED_EXTENSIONS:
+        extension = ".jpg"
+
+    stored_filename = f"{uuid4()}{extension}"
+    stored_path = UPLOAD_DIR / stored_filename
+    UPLOAD_DIR.mkdir(parents=True, exist_ok=True)
+    stored_path.write_bytes(image_bytes)
+
+    inspection = Inspection(
+        image_path=f"uploads/{stored_filename}",
+        status="PENDING",
+    )
+
+    try:
+        db.add(inspection)
+        db.commit()
+        db.refresh(inspection)
+    except Exception:
+        db.rollback()
+        stored_path.unlink(missing_ok=True)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Could not create the scan record.",
+        )
+
+    return {
+        "scan_id": inspection.id,
+        "filename": stored_filename,
+        "status": inspection.status,
+    }


### PR DESCRIPTION
## Summary
- Added image upload endpoint
- Save uploaded images with generated filenames
- Create a pending inspection record
- Return the scan ID for future processing

## Endpoint
POST `/api/v1/uploads/image`

## Validation
- Rejects non-image files
- Rejects empty uploads
- Removes the saved file if database creation fails